### PR TITLE
Do not include .scss files in generated output

### DIFF
--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -1,3 +1,6 @@
+sculpin:
+    ignore: ["**/*.scss"]
+
 sculpin_content_types:
     posts:
         permalink: blog/:year/:month/:day/:filename/


### PR DESCRIPTION
Prevents .scss files from being copied over to the output_* directories.